### PR TITLE
amazon: add support for limiting to a single year

### DIFF
--- a/docdl/plugins/amazon.py
+++ b/docdl/plugins/amazon.py
@@ -288,7 +288,7 @@ class Amazon(docdl.SeleniumWebPortal):
 )
 @click.option(
     "-y",
-    "--limit_year",
+    "--limit-year",
     type=int,
     envvar="DOCDL_LIMIT_YEAR",
     show_envvar=True,

--- a/docdl/plugins/amazon.py
+++ b/docdl/plugins/amazon.py
@@ -97,8 +97,8 @@ class Amazon(docdl.SeleniumWebPortal):
         limit_year = self.arguments['limit_year']
         for option in options:
             # skip years in limited mode
-            if limit_year and option != "year-{}".format(limit_year):
-                # debug("skipping option {} due to limit_year set to {}".format(option, limit_year))
+            if limit_year and option != f"year-{limit_year}":
+                # debug(f"skipping option {option} due to limit_year set to {limit_year}")
                 continue
             # go back to order overview except if we already are on
             # the overview page

--- a/docdl/plugins/amazon.py
+++ b/docdl/plugins/amazon.py
@@ -94,7 +94,12 @@ class Amazon(docdl.SeleniumWebPortal):
         # get options from orderfilter so we get all available invoices
         options = self._orderfilter_options()
         # iterate all years (+ archived orders)
+        limit_year = self.arguments['limit_year']
         for option in options:
+            # skip years in limited mode
+            if limit_year and option != "year-{}".format(limit_year):
+                # debug("skipping option {} due to limit_year set to {}".format(option, limit_year))
+                continue
             # go back to order overview except if we already are on
             # the overview page
             if "order-details" in self.webdriver.current_url:
@@ -280,6 +285,16 @@ class Amazon(docdl.SeleniumWebPortal):
     envvar="DOCDL_AMAZON_TLD",
     show_envvar=True,
     help="toplevel domain to use"
+)
+@click.option(
+    "-y",
+    "--limit_year",
+    type=int,
+    envvar="DOCDL_LIMIT_YEAR",
+    show_envvar=True,
+    default=None,
+    help="limit handling to documents of the given year",
+    show_default=True
 )
 @click.pass_context
 # pylint: disable=W0613


### PR DESCRIPTION
It is already possible to filter for documents (or orders, in Amazon context) of a certain year. Nevertheless, documents for all years will be inspected which can become time-consuming. This PR adds a feature to filter so processing is limited as well.

Currently, it is only implemented for the Amazon plugin. A global "--year" switch might be well worth considering but would also involve API changes. Therefor I chose to only propose this first step.

