### PR TITLE
new feature: preserve document time as file mtime

### DIFF
--- a/docdl/cli.py
+++ b/docdl/cli.py
@@ -1,5 +1,6 @@
 """download documents from web portals"""
 
+import os
 import pkg_resources
 import click
 import click_plugins
@@ -86,6 +87,16 @@ import docdl
     show_default=True
 )
 @click.option(
+    "-T",
+    "--time-preserve",
+    type=bool,
+    default=True,
+    envvar="DOCDL_TIME_PRESERVE",
+    show_envvar=True,
+    help="preserve the document creation time for the downloaded file",
+    show_default=True
+)
+@click.option(
     "-t",
     "--timeout",
     type=int,
@@ -131,7 +142,7 @@ import docdl
 # pylint: disable=W0613,C0103,R0913
 def documentdl(
     ctx, username, password, string_matches, regex_matches, jq_matches,
-    headless, browser, timeout, image_loading, action, output_format
+    headless, browser, time_preserve, timeout, image_loading, action, output_format
 ):
     """download documents from web portals"""
     # set browser that SeleniumWebPortal plugins should use
@@ -179,7 +190,10 @@ def run(ctx, plugin_class):
                 continue
             # download ?
             if root_params['action'] == "download":
-                portal.download(document)
+                filename = portal.download(document)
+                if root_params['time_preserve']:
+                    timest = document.attributes['date'].timestamp()
+                    os.utime(filename, (timest, timest))
             # line buffered dict output?
             if root_params['output_format'] == "dicts":
                 # always output as json dict


### PR DESCRIPTION
Metadata is always nice to have, but having it, we should also use it. Specifically, set the file mtime to the document date. Actually, I even think that should be the default option. The download time is still available in other attributes, but I don't really see where it'd be important.

This might just as well fit into `rename_after_download` which should then be `postprocess_after_download`, but I had no strong preference so it landed in cli.py.

Up to now I didn't check whether the date attribute acutally exists. I guess it should for any document.

Regarding click options: I find it strange to supply "=true" to bool options. Imho such options should be simple switches to enable the non-default behaviour (e.g. also in `--headless`) -- which is common for a lot of other programs. However, for now I've kept with the existing style.