### PR TITLE
use selenium<4.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         'jq',
         'python-dateutil',
         'requests',
-        'selenium',
+        'selenium<4.3.0',
         'watchdog'
     ],
     packages=find_packages(exclude=['tests*']),


### PR DESCRIPTION
selenium 4.3.0 deprecated Opera and find_element_by_* which is still used here. so we need to use an earlier version.

selenium changelog:
https://github.com/SeleniumHQ/selenium/blob/a4995e2c096239b42c373f26498a6c9bb4f2b3e7/py/CHANGES